### PR TITLE
HTML::Element: New dumping methods 'as_lol' and 'content_as_lol'.

### DIFF
--- a/t/as-lol.t
+++ b/t/as-lol.t
@@ -1,0 +1,67 @@
+#! /usr/bin/perl
+#---------------------------------------------------------------------
+# Test the as_lol & content_as_lol methods
+
+use strict;
+use warnings;
+
+use Test::More 0.88;            # done_testing
+
+use HTML::Element;
+
+plan tests => 21;
+
+#---------------------------------------------------------------------
+sub t
+{
+    my ($name, $lol, $expected, $content_offset) = @_;
+
+    # We trust new_from_lol here. This looks like cheating, but it isn't.
+    my $tree = HTML::Element->new_from_lol($lol);
+
+    isa_ok($tree, 'HTML::Element', $name);
+
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    is_deeply($tree->as_lol(), $expected, "$name as_lol");
+
+    # The content starts at $content_offset, extract those
+    my @expected_content = @{$expected};
+    splice(@expected_content, 0, $content_offset);
+
+    # Compare deeply by wrapping in an arrayref - we've got lists, after all.
+    is_deeply([$tree->content_as_lol()], [@expected_content], "$name content_as_lol");
+
+} # end t
+
+#---------------------------------------------------------------------
+
+t('simple container',
+    [p => 'Hello'],
+    [p => 'Hello'],
+1);
+t('nested containers',
+    [p => 'Hello', [b => ' World'], '!'],
+    [p => 'Hello', [b => ' World'], '!'],
+1);
+t('with attributes',
+    [p => 'Hello ', [a => { href => 'http://example.com', title => 'Example'}, 'example']],
+    [p => 'Hello ', [a => { href => 'http://example.com', title => 'Example'}, 'example']],
+1);
+t('with top-level attributes',
+    [p => 'Hello ', 'World', { class => 'example'}],
+    [p => {class => 'example'}, 'Hello ', 'World'],
+2);
+t('with multiple top-level attributes',
+    [p => 'Hello ', { class => 'example'}, [b => 'World'], {id => 'p-example'}],
+    [p => {class => 'example', id => 'p-example'}, 'Hello ', [b => 'World']],
+2);
+t('empty',
+    ['br'],
+    ['br'],
+1);
+t('empty attributes',
+    ['br', {}],
+    ['br'],
+1);
+#---------------------------------------------------------------------
+done_testing;


### PR DESCRIPTION
I've always found it odd that there was a `new_from_lol` method, but no corresponding dumpers. Now I'm working on a project where such a dumping method might actually come in handy. Also, it allows DOM-based tests via `is_deeply`.

So I wrote one (well, two: `as_lol` and `content_as_lol`), and here it is, for your consideration. Naturally, I can change any part of the patch, be it code, idioms, indentation, or POD.

_Point of discussion_: I had originally wanted to offer an option to force an attribute hash ref, even if empty, but I can work around that in my project, so I didn't implement it. Would such an option still be useful?
